### PR TITLE
Add HomeBrew include and library directories on Mac

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -24,6 +24,8 @@
         ['OS=="linux"', {'libraries': ['-lAntTweakBar', '<!@(pkg-config --libs glfw3 glew)']}],
         ['OS=="mac"', {
           'libraries': ['-lAntTweakBar', '-lglfw3', '-lGLEW', '-framework OpenGL'],
+          'include_dirs': ['/usr/local/include'],
+          'library_dirs': ['/usr/local/lib'],
         }],
         ['OS=="win"', {
           'libraries': [


### PR DESCRIPTION
The recent `clang` from `XCode` distribution does not look into `/usr/local/include` and `/usr/local/lib` directories. This patch adds them explicitly.
